### PR TITLE
various changes I used in CS 4414

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,8 +224,10 @@ You may optionally also include
     be replaced with the assignment due time, and `CLOSE_TIME` with its closed time. Default is 
     `"is due DUE_TIME; you may subimit fixes until CLOSE_TIME"`.
 
--   `grading-show-sub`: if set, show an option in the grader to subtract an amount from the grade
+-   `grading-show-sub`: if set to true, show an option in the grader to subtract an amount from the grade
     as a special case adjustment
+
+-   `show-late-estimate-on-submit`: if set to true, show an estimate of the late penalty a student receive on submission in addition to mentioning that their submission will be late.
 
 ## Rubrics and `.grade`s
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,10 @@ The following keys, if present, also have defined meaning:
 
 -  `hide`: if set, don't show this assignment to students at all or use it for grade computations
 
--  `feedback_files`: list of glob patterns for files that should be considered feedback (e.g. autograder outputs)
+-  `feedback-files`: list of glob patterns for files that should be considered feedback (e.g. autograder outputs)
+
+-  `not-submittable-message`: if set, message to show on the index of assignments if this assignment has
+    no `files` to submit. Default is "not submittable online".
     
 ## `coursegrade.json`
 
@@ -215,11 +218,11 @@ You may optionally also include
 
 -   `no-queue`, an object with keys being assignment `group`s that should not be queued for automated feedback when submitted and values to display upon submission (not displayed if `""`).
 
--   `past_due_message`, message to display on past-due assignments on the submission page. `DUE_TIME` will
+-   `past-due-message`, message to display on past-due assignments on the submission page. `DUE_TIME` will
     be replaced with the assignment due time, and `CLOSE_TIME` with its closed time. Default is 
     `"is due DUE_TIME; you may subimit fixes until CLOSE_TIME"`.
 
--   `grading_show_sub`: if set, show an option in the grader to subtract an amount from the grade
+-   `grading-show-sub`: if set, show an option in the grader to subtract an amount from the grade
     as a special case adjustment
 
 ## Rubrics and `.grade`s

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ The following keys, if present, also have defined meaning:
 
 -  `not-submittable-message`: if set, message to show on the index of assignments if this assignment has
     no `files` to submit. Default is "not submittable online".
+
+-  `link-description`: text to display on writeup link. Default is "Task description".
     
 ## `coursegrade.json`
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ The following keys, if present, also have defined meaning:
     Defaults to `1` if omitted.
     For example, if two midterms and the final exam are the entries of the `"Exam"` group
     and the final has `"weight":2`, the total grade for the exam group will be $(m_1 + m_2 + 2 m_3) \div 4$.
+
+-  `single-file`: if set, only expect a single file to be submitted for this assignment. Anything other than
+    the most recently submitted file will be displayed as "Older submissions".
+
+-  `withhold`: if set, don't show grades for this assignment to students
+
+-  `hide`: if set, don't show this assignment to students at all or use it for grade computations
+
+-  `feedback_files`: list of glob patterns for files that should be considered feedback (e.g. autograder outputs)
     
 ## `coursegrade.json`
 
@@ -205,6 +214,13 @@ You may optionally also include
     Currently values are ignored.
 
 -   `no-queue`, an object with keys being assignment `group`s that should not be queued for automated feedback when submitted and values to display upon submission (not displayed if `""`).
+
+-   `past_due_message`, message to display on past-due assignments on the submission page. `DUE_TIME` will
+    be replaced with the assignment due time, and `CLOSE_TIME` with its closed time. Default is 
+    `"is due DUE_TIME; you may subimit fixes until CLOSE_TIME"`.
+
+-   `grading_show_sub`: if set, show an option in the grader to subtract an amount from the grade
+    as a special case adjustment
 
 ## Rubrics and `.grade`s
 
@@ -280,6 +296,21 @@ as well as how much to deduct the late score.
     ,".mult":{"kind":"percentage","ratio":0.8,"comments":"professionalism penalty"}
     }
     ````
+
+The items in `human` portion of the rubric can include a `"kind"` key, which can have any of the following values
+    
+    *  radio3 (default): full/half/none radio options
+    *  radio5: full/three-quarters/half/one-quarter/none radio options
+    *  points: ask for a number of points based on the weight of the option
+    *  comment: provide a field for writing a comment; "weight" must be none
+
+In addition the following keys are supported on each rubric item:
+
+    *  `sometimes_na`: if set, then provide an N/A option when grading (with one of the radio types) that
+       sets weight of the option to 0 for this student
+    *  `allow_comment`: if set, allow specifying a comment for this item in the grading interface. This comment
+        is separate from a comment on the overall grade.
+
 
 
 ## `.autograde`

--- a/README.md
+++ b/README.md
@@ -229,6 +229,8 @@ You may optionally also include
 
 -   `show-late-estimate-on-submit`: if set to true, show an estimate of the late penalty a student receive on submission in addition to mentioning that their submission will be late.
 
+-   `show-score-before-adjustments`: if set to true, show the score of assignments before multiplication/etc. adjustments (including late penalties) in addition to the final score
+
 ## Rubrics and `.grade`s
 
 Rubrics are specified in JSON objects.

--- a/display.css
+++ b/display.css
@@ -106,6 +106,7 @@ div.grade + div { white-space: pre-wrap; }
 .check.correct, .full.credit, label.full { background-color:rgba(0,255,0,0.25); }
 .check.wrong, .no.credit, label.none { background-color:rgba(255,0,0,0.25); }
 .check.partial, .partial.credit, label.partial { background-color:rgba(255,255,0,0.25); }
+.check.na, .na.credit, label.na { background-color:rgba(100,100,100,0.25); }
 table.feedback tr td:first-child { text-align: center; }
 table.feedback tr td { border: rgba(0,0,0,0) 0.5ex solid; }
 table.feedback tr.break td { border: thin solid black; padding:0; }

--- a/grade.php
+++ b/grade.php
@@ -111,13 +111,17 @@ function percent_tag($id, $text, $percent, $comment) {
 }
 
 function item_tag($id, $name, $select=False, $weight_zero=False, $sometimes_na=False) {
-	$sna = '';
+    $sna = '';
+    $s34 = '';
+    $s14 = '';
     if ($weight_zero && $sometimes_na) {
         $sna = "checked='checked'";
         $sf = ''; $sp = ''; $sn = '';
     } else if ($select !== False) {
         $sf = $select == 1.0 ? "checked='checked' " : "";
+        $s34 = $select == 0.75 ? "checked='checked' " : "";
         $sp = $select == 0.5 ? "checked='checked' " : "";
+        $s14 = $select == 0.25 ? "checked='checked' " : "";
         $sn = $select == 0.0 ? "checked='checked' " : "";
     } else {
         $sf = ''; $sp = ''; $sn = '';
@@ -125,11 +129,11 @@ function item_tag($id, $name, $select=False, $weight_zero=False, $sometimes_na=F
     $result = "<div class='item'>
         <label class='full'><input type='radio' name='$id' value='1.0' $sf/>1</label>
         <!--<label class='partial'><input type='radio' name='$id' value='0.825' $sp/>⅞</label>-->
-        <label class='partial'><input type='radio' name='$id' value='0.75' $sp/>¾</label>
+        <label class='partial'><input type='radio' name='$id' value='0.75' $s34/>¾</label>
         <!--<label class='partial'><input type='radio' name='$id' value='0.625' $sp/>⅝</label>-->
         <label class='partial'><input type='radio' name='$id' value='0.5' $sp/>½</label>
         <!--<label class='partial'><input type='radio' name='$id' value='0.375' $sp/>⅜</label>-->
-        <label class='partial'><input type='radio' name='$id' value='0.25' $sp/>¼</label>
+        <label class='partial'><input type='radio' name='$id' value='0.25' $s14/>¼</label>
         <!--<label class='partial'><input type='radio' name='$id' value='0.125' $sp/>⅛</label>-->
         <label class='none'><input type='radio' name='$id' value='0.0' $sn/>0</label>";
     if ($sometimes_na !== False) {

--- a/grade.php
+++ b/grade.php
@@ -45,6 +45,8 @@ if (array_key_exists('addgrade', $_REQUEST)) {
     # preserve hidden information
     if (array_key_exists('grade', $details)) {
         foreach ($details['grade'] as $k => $v) {
+            # FIXME: hack
+            if ($k == '.adjustment') { continue; }
             if (!array_key_exists($k, $grade)) {
                 $grade[$k] = $v;
             }

--- a/grade.php
+++ b/grade.php
@@ -124,7 +124,10 @@ function item_tag($id, $name, $select=False, $weight_zero=False, $sometimes_na=F
     }
     $result = "<div class='item'>
         <label class='full'><input type='radio' name='$id' value='1.0' $sf/>1</label>
+        <label class='partial'><input type='radio' name='$id' value='0.25' $sp/>¼</label>
         <label class='partial'><input type='radio' name='$id' value='0.5' $sp/>½</label>
+        <label class='partial'><input type='radio' name='$id' value='0.75' $sp/>¾</label>
+        <label class='partial'><input type='radio' name='$id' value='0.825' $sp/>⅞</label>
         <label class='none'><input type='radio' name='$id' value='0.0' $sn/>0</label>";
     if ($sometimes_na !== False) {
         $result .= "<label class='na'><input type='radio' name='$id' value='N/A' $sna/>N/A</label>";

--- a/grade.php
+++ b/grade.php
@@ -183,6 +183,8 @@ function hybrid_tree($details) {
         $ontime = '';
         $late = '';
     }
+    $ontime = ''; # FIXME
+    $late = '';
     
     $items = array();
     if (!array_key_exists('grade', $details) && array_key_exists('grade_template', $details)) {

--- a/grade.php
+++ b/grade.php
@@ -56,7 +56,7 @@ if (array_key_exists('addgrade', $_REQUEST) || array_key_exists('respondtoregrad
         $rub = rubricOf($grade['slug']);
         if ($rub['kind'] != $grade['kind']) die("expected '$rub[kind]' (not '$grade[kind]') for $grade[slug]");
         if ($grade['kind'] == 'hybrid') {
-            // add rubric details
+		// add rubric details
             $grade['auto-weight'] = $rub['auto-weight'];
             $grade['late-penalty'] = $rub['late-penalty'];
             // and computed values
@@ -124,10 +124,13 @@ function item_tag($id, $name, $select=False, $weight_zero=False, $sometimes_na=F
     }
     $result = "<div class='item'>
         <label class='full'><input type='radio' name='$id' value='1.0' $sf/>1</label>
-        <label class='partial'><input type='radio' name='$id' value='0.25' $sp/>¼</label>
-        <label class='partial'><input type='radio' name='$id' value='0.5' $sp/>½</label>
-        <label class='partial'><input type='radio' name='$id' value='0.75' $sp/>¾</label>
         <label class='partial'><input type='radio' name='$id' value='0.825' $sp/>⅞</label>
+        <label class='partial'><input type='radio' name='$id' value='0.75' $sp/>¾</label>
+        <label class='partial'><input type='radio' name='$id' value='0.625' $sp/>⅝</label>
+        <label class='partial'><input type='radio' name='$id' value='0.5' $sp/>½</label>
+        <label class='partial'><input type='radio' name='$id' value='0.375' $sp/>⅜</label>
+        <label class='partial'><input type='radio' name='$id' value='0.25' $sp/>¼</label>
+        <label class='partial'><input type='radio' name='$id' value='0.125' $sp/>⅛</label>
         <label class='none'><input type='radio' name='$id' value='0.0' $sn/>0</label>";
     if ($sometimes_na !== False) {
         $result .= "<label class='na'><input type='radio' name='$id' value='N/A' $sna/>N/A</label>";
@@ -174,7 +177,7 @@ function hybrid_tree($details) {
         $ontime = round($details['ontime']['correctness'] * 100, 1) . '% correct when due';
         $late = round($details['autograde']['correctness'] * 100, 1) . '% correct eventually';
     } else if (array_key_exists('autograde', $details)) {
-        $ontime = round($details['autograde']['correctness'] * 100, 1) . '% correct';
+        $ontime = ''; # FIXME round($details['autograde']['correctness'] * 100, 1) . '% correct';
         $late = '';
     } else {
         $ontime = '';
@@ -185,7 +188,6 @@ function hybrid_tree($details) {
     if (!array_key_exists('grade', $details) && array_key_exists('grade_template', $details)) {
 	$details['grade'] = $details['grade_template'];
     }
-    echo('creating hybrid tree<br>');
     foreach($details['rubric']['human'] as $i=>$item) {
         $sometimes_na = False;
         $name = $item;

--- a/grade.php
+++ b/grade.php
@@ -261,6 +261,9 @@ function hybrid_tree($details) {
 	    $select = $details['grade']['human'][$i]['ratio'];
 	    $weight = $details['grade']['human'][$i]['weight'];
             $comment = $details['grade']['human'][$i]['comment'];
+            if (strlen($comment) == 0 && array_key_exists('comments', $details['grade']['human'][$i])) {
+                $comment = $details['grade']['human'][$i]['comments'];
+            }
 	} else {
             $select = False;
             $weight = $item['weight'];

--- a/grade.php
+++ b/grade.php
@@ -114,7 +114,7 @@ function percent_tag($id, $text, $percent, $comment) {
 }
 
 function item_tag($id, $name, $key, $select=False, $weight_zero=False, $sometimes_na=False, $prompt_points=False) {
-    $data = "data-key='$key' data-name='$name' name='$id'"
+    $data = "data-key='$key' data-name='$name' name='$id'";
     if ($prompt_points) { 
         if ($select !== False) {
             $value = $select * $prompt_points;

--- a/grade.php
+++ b/grade.php
@@ -124,13 +124,13 @@ function item_tag($id, $name, $select=False, $weight_zero=False, $sometimes_na=F
     }
     $result = "<div class='item'>
         <label class='full'><input type='radio' name='$id' value='1.0' $sf/>1</label>
-        <label class='partial'><input type='radio' name='$id' value='0.825' $sp/>⅞</label>
+        <!--<label class='partial'><input type='radio' name='$id' value='0.825' $sp/>⅞</label>-->
         <label class='partial'><input type='radio' name='$id' value='0.75' $sp/>¾</label>
-        <label class='partial'><input type='radio' name='$id' value='0.625' $sp/>⅝</label>
+        <!--<label class='partial'><input type='radio' name='$id' value='0.625' $sp/>⅝</label>-->
         <label class='partial'><input type='radio' name='$id' value='0.5' $sp/>½</label>
-        <label class='partial'><input type='radio' name='$id' value='0.375' $sp/>⅜</label>
+        <!--<label class='partial'><input type='radio' name='$id' value='0.375' $sp/>⅜</label>-->
         <label class='partial'><input type='radio' name='$id' value='0.25' $sp/>¼</label>
-        <label class='partial'><input type='radio' name='$id' value='0.125' $sp/>⅛</label>
+        <!--<label class='partial'><input type='radio' name='$id' value='0.125' $sp/>⅛</label>-->
         <label class='none'><input type='radio' name='$id' value='0.0' $sn/>0</label>";
     if ($sometimes_na !== False) {
         $result .= "<label class='na'><input type='radio' name='$id' value='N/A' $sna/>N/A</label>";
@@ -216,6 +216,13 @@ function hybrid_tree($details) {
         $hasmult ? htmlspecialchars($details['grade']['.mult']['comments']) : ''
     );
     
+    $hassub = array_key_exists('grade', $details) && array_key_exists('.sub',$details['grade']);
+    $sub = percent_tag(
+        "$id|sub", 
+        "grade subtraction",
+        $hassub ? $details['grade']['.sub']['portion']*100 : '',
+        $hassub ? htmlspecialchars($details['grade']['.sub']['comments']) : ''
+    );
     $comment = (array_key_exists('grade', $details) && array_key_exists('comments', $details['grade'])) ? htmlspecialchars($details['grade']['comments']) : '';
     
     // FIXME: there is currently no way to handle .adjustment files from this interface
@@ -229,6 +236,9 @@ function hybrid_tree($details) {
         <div class='comment'><span>Comment:</span><textarea id='$id|comment'>$comment</textarea></div>
         <div class='hide-outer hidden'><strong class='hide-header'>Multiplier (for special cases)</strong><div class='hide-inner'>
         $mult
+        </div></div>
+        <div class='hide-outer hidden'><strong class='hide-header'>Subtraction (for special cases)</strong><div class='hide-inner'>
+        $sub
         </div></div>
     </div>";
 }
@@ -771,8 +781,10 @@ if (array_key_exists('assignment', $_REQUEST)) {
         if (!$grader && count($stats['graders']) == 1) $grader = 'all';
         
         if ($redo == 'review' && $grader) {
-            echo "<h2>For $slug, you graded (most recent first):</h2><ul class='linklist'>";
-            foreach(array_reverse(toGrade($slug, $grader, $redo)) as $student) {
+            $list = toGrade($slug, $grader, $redo);
+            $count = count($list); 
+            echo "<h2>For $slug, you graded $count submissions (most recent first):</h2><ul class='linklist'>";
+            foreach(array_reverse($list) as $student) {
                 $stud = fullRoster()[$student];
                 echo "<li><a href='?assignment=$slug&student=$student'>$stud[name] ($student)</a>";
                 if ($grader != 'all') {

--- a/grade.php
+++ b/grade.php
@@ -571,7 +571,7 @@ function gradeableTree($limit=False) {
                     'ungraded'=>0,
                     'graders'=>array(),
                 );
-                if ($gid != 'no grader' && !$issuperuser)
+                if ($gid != 'no grader' || $issuperuser)
                     $ans[$slug][$status] += 1;
 
                 if (!array_key_exists($gid, $ans[$slug]['graders'])) $ans[$slug]['graders'][$gid] = array(

--- a/grade.php
+++ b/grade.php
@@ -78,7 +78,9 @@ if (array_key_exists('addgrade', $_REQUEST) || array_key_exists('respondtoregrad
                 } else {
                     if ($grade['human'][$i]['name'] != $val['name']) die('rubric has changed');
                 }
-                $grade['human'][$i]['weight'] = $val['weight'];
+                if (!array_key_exists('weight', $grade['human'][$i])) {
+                    $grade['human'][$i]['weight'] = $val['weight'];
+                } 
             }
         }
         
@@ -208,7 +210,7 @@ function hybrid_tree($details) {
 	    $select = $details['grade']['human'][$i]['ratio'];
 	    $weight_zero = $details['grade']['human'][$i]['weight'] == 0.0;
 	} else $select = False;
-        $items[] = item_tag("$id|$i", htmlspecialchars($name), $select, $weight_zero, $sometimes_na);
+        $items[] = "<!-- weight " . $details['grade']['human'][$i]['weight'] .  "-->" . item_tag("$id|$i", htmlspecialchars($name), $select, $weight_zero, $sometimes_na);
     }
     $items = implode("\n            ", $items);
     
@@ -474,9 +476,11 @@ function _grade(id) {
             num = Number(num[num.length-1]);
             if (num >= ans.human.length) ans.human.push(null);
             if (x.checked) {
-                if (x.value=="N/A") {
+                if (x.value == "N/A") {
+                    console.log("found na for " + num);
                     ans.human[num] = {ratio:0.0, weight:0.0, name:key};
                 } else {
+                    console.log("found " + x.value + " for " + num);
                     ans.human[num] = {ratio:Number(x.value), name:key};
                 }
                 x.parentElement.parentElement.classList.remove('error');

--- a/grade.php
+++ b/grade.php
@@ -551,7 +551,7 @@ function gradeableTree($limit=False) {
                 && closeTime(json_decode(file_get_contents("$dir/.extension"),true)) > time()) {
                     continue;
                 }
-                if (count(glob("$dir/*", GLOB_NOSORT)) == 0) { continue; } // no submission
+                if (count(glob("$dir/*", GLOB_NOSORT)) == 0 && !file_exists("$dir/.grade")) { continue; } // no submission
                 $sid = explode('/',$dir)[2];
                 if (!array_key_exists($sid, $everyone)) continue; // non-student directory or file
                 if (file_exists("$dir/.partners")) {

--- a/grade.php
+++ b/grade.php
@@ -136,8 +136,8 @@ function percent_tree($details) {
     $sub = percent_tag(
         "$id|sub", 
         "grade subtraction",
-        $hasmult ? $details['grade']['.sub']['portion']*100 : '',
-        $hasmult ? htmlspecialchars($details['grade']['.sub']['comments']) : ''
+        $hassub ? $details['grade']['.sub']['portion']*100 : '',
+        $hassub ? htmlspecialchars($details['grade']['.sub']['comments']) : ''
     );
     return "
         <div class='percentage-outer' id='$id|outer'>

--- a/grade.php
+++ b/grade.php
@@ -210,7 +210,7 @@ function percent_tree($details) {
         $hasmult ? htmlspecialchars($details['grade']['.mult']['comments']) : ''
     );
     $hassub = array_key_exists('grade', $details) && array_key_exists('.sub', $details['grade']);
-    if ($hassub || (array_key_exists("grading_show_sub", $metadata) && $metadata['grading_show_sub'])) {
+    if ($hassub || (array_key_exists("grading-show-sub", $metadata) && $metadata['grading-show-sub'])) {
         $sub = percent_tag(
             "$id|sub", 
             "grade subtraction",

--- a/grade.php
+++ b/grade.php
@@ -571,7 +571,7 @@ function gradeableTree($limit=False) {
                     'ungraded'=>0,
                     'graders'=>array(),
                 );
-                if ($gid != 'no grader')
+                if ($gid != 'no grader' && !$issuperuser)
                     $ans[$slug][$status] += 1;
 
                 if (!array_key_exists($gid, $ans[$slug]['graders'])) $ans[$slug]['graders'][$gid] = array(

--- a/grade.php
+++ b/grade.php
@@ -209,13 +209,17 @@ function percent_tree($details) {
         $hasmult ? $details['grade']['.mult']['ratio']*100 : '',
         $hasmult ? htmlspecialchars($details['grade']['.mult']['comments']) : ''
     );
-    $hassub = array_key_exists('grade', $details) && array_key_exists('.sub',$details['grade']);
-    $sub = percent_tag(
-        "$id|sub", 
-        "grade subtraction",
-        $hassub ? $details['grade']['.sub']['portion']*100 : '',
-        $hassub ? htmlspecialchars($details['grade']['.sub']['comments']) : ''
-    );
+    $hassub = array_key_exists('grade', $details) && array_key_exists('.sub', $details['grade']);
+    if ($hassub || (array_key_exists("grading_show_sub", $metadata) && $metadata['grading_show_sub'])) {
+        $sub = percent_tag(
+            "$id|sub", 
+            "grade subtraction",
+            $hassub ? $details['grade']['.sub']['portion']*100 : '',
+            $hassub ? htmlspecialchars($details['grade']['.sub']['comments']) : ''
+        );
+    } else {
+        $sub = "";
+    }
     return "
         <div class='percentage-outer' id='$id|outer'>
             $innertag
@@ -232,7 +236,7 @@ function hybrid_tree($details) {
         $ontime = round($details['ontime']['correctness'] * 100, 1) . '% correct when due';
         $late = round($details['autograde']['correctness'] * 100, 1) . '% correct eventually';
     } else if (array_key_exists('autograde', $details)) {
-        $ontime = ''; # FIXME round($details['autograde']['correctness'] * 100, 1) . '% correct';
+        $ontime = round($details['autograde']['correctness'] * 100, 1) . '% correct';
         $late = '';
     } else {
         $ontime = '';

--- a/grade.php
+++ b/grade.php
@@ -81,8 +81,8 @@ if (array_key_exists('addgrade', $_REQUEST) || array_key_exists('respondtoregrad
                 if (!array_key_exists('weight', $grade['human'][$i])) {
                     $grade['human'][$i]['weight'] = $val['weight'];
                 }
-                if (array_key_exists('type', $val)) {
-                    $grade['human'][$i]['type'] = $val['type'];
+                if (array_key_exists('kind', $val)) {
+                    $grade['human'][$i]['kind'] = $val['kind'];
                 }
                 if (array_key_exists('key', $val)) {
                     $grade['human'][$i]['key'] = $val['key'];
@@ -122,23 +122,23 @@ function item_tag($id, $rubric, $selected, $weight, $comment) {
     $key = htmlspecialchars($rubric["key"]);
     $name = htmlspecialchars($rubric["name"]);
     $rubric_weight = $rubric["weight"];
-    $type = "radio";
-    if (array_key_exists("type", $rubric)) {
-        $type = $rubric["type"];
+    $kind = "radio3";
+    if (array_key_exists("kind", $rubric)) {
+        $kind = $rubric["kind"];
     }
     $data = "data-key='$key' data-name='$name' name='$id' data-weight='$weight' data-current-weight='$weight' data-current-selected='$selected'";
-    if ($type == "comment") {
+    if ($kind == "comment") {
         $result = "<div class='item'>
             <label for='$id'>$name</label>:
             </div>
         ";
         $result .= "
             <div class='itemcomment'><label for='$id|comment'>Standalone comment:</label>
-            <textarea $data data-is-item-comment='yes' id='$id|comment'>$comment</textarea>
+            <textarea $data data-is-item-comment='yes' id='$id|comment'>$comments</textarea>
             </div>
         ";
         return $result;
-    } else if ($type == "points") { 
+    } else if ($kind == "points") { 
         if ($selected !== False) {
             $value = $selected * $weight;
         } else {
@@ -157,11 +157,12 @@ function item_tag($id, $rubric, $selected, $weight, $comment) {
         }
         return $result;
     } else {
-        $result = "<div class='item'>";
-        $options = [[1.0, "1"], [0.75, "¾"], [0.5, "½"], [0.25, "¼"], [0.0, "0"]];
-        if ($type == "radio3") {
+        if ($kind == "radio5") {
+            $options = [[1.0, "1"], [0.75, "¾"], [0.5, "½"], [0.25, "¼"], [0.0, "0"]];
+        } else {
             $options = [[1.0, "1"], [0.5, "½"], [0.0, "0"]];
         }
+        $result = "<div class='item'>";
         $sometimes_na = array_key_exists('sometimes_na', $rubric) && $rubric['sometimes_na'];
         foreach ($options as $option) {
             $cur_selected = ($selected == $option[0]);
@@ -248,7 +249,7 @@ function hybrid_tree($details) {
         $sometimes_na = False;
         $prompt_points = False;
         if (!is_array($item)) {
-            $item = array('name' => $item, 'key' => $item, 'weight' => 1.0, 'type' => 'radio');
+            $item = array('name' => $item, 'key' => $item, 'weight' => 1.0, 'kind' => 'radio');
         }
         if (!array_key_exists($item, 'key')) {
             $item['key'] = $item['name'];
@@ -260,10 +261,7 @@ function hybrid_tree($details) {
 	) {
 	    $select = $details['grade']['human'][$i]['ratio'];
 	    $weight = $details['grade']['human'][$i]['weight'];
-            $comment = $details['grade']['human'][$i]['comment'];
-            if (strlen($comment) == 0 && array_key_exists('comments', $details['grade']['human'][$i])) {
-                $comment = $details['grade']['human'][$i]['comments'];
-            }
+            $comment = $details['grade']['human'][$i]['comments'];
 	} else {
             $select = False;
             $weight = $item['weight'];
@@ -565,7 +563,7 @@ function _grade(id) {
             if (ans.human[num] == null) {
                 ans.human[num] = {name: name, weight: 0}
             }
-            ans.human[num]['comment'] = x.value;
+            ans.human[num]['comments'] = x.value;
             x.parentElement.parentElement.classList.remove('error');
         });
         var ok = true

--- a/grade.php
+++ b/grade.php
@@ -16,16 +16,6 @@ if (array_key_exists('addgrade', $_REQUEST)) {
     if (!array_key_exists('slug', $grade) || !array_key_exists('student', $grade)) die ("grade payload missing required keys");
     $grade['timestamp'] = time();
 
-    $details = asgn_details($grade['student'], $grade['slug']);
-    # preserve hidden information
-    if (array_key_exists('grade', $details)) {
-        foreach ($details['grade'] as $k => $v) {
-            if (!array_key_exists($k, $details)) {
-                $grade[$k] = $v;
-            }
-        }
-    }
-
     // log regrade chatter
     $reqfile = "meta/requests/regrade/$grade[slug]-$grade[student]";
     if (array_key_exists('regrade', $grade) && file_exists($reqfile)) {
@@ -49,6 +39,16 @@ if (array_key_exists('addgrade', $_REQUEST)) {
         );
         unset($grade['regrade']);
         file_put($chatfile, json_encode($chatter)) || die('failed to record decision (may be server permission error?)');
+    }
+    
+    $details = asgn_details($grade['student'], $grade['slug']);
+    # preserve hidden information
+    if (array_key_exists('grade', $details)) {
+        foreach ($details['grade'] as $k => $v) {
+            if (!array_key_exists($k, $grade)) {
+                $grade[$k] = $v;
+            }
+        }
     }
     
     $rub = rubricOf($grade['slug']);

--- a/gradesheet.php
+++ b/gradesheet.php
@@ -68,6 +68,7 @@ if (!hasFacultyRole($me)) { die("<p>Only faculty may view this page</p></body></
         <th onclick="sortcolumn('tbody',1,true)">Name ⇕</th>
         <th onclick="sortcolumn('tbody',2,true)">Section ⇕</th>
         <th onclick="sortcolumn('tbody',3,true)">Grade ⇕</th>
+        <th onclick="sortcolumn('tbody',4,true)">Earned ⇕</th>
         <th>Letter</th>
         <th>Progress</th>
 </tr></thead>
@@ -97,6 +98,7 @@ foreach(fullRoster() as $id=>$details) {
     echo "<td>$section</td>"; // Groups
     echo "<td>$final</td><td>";
     echo letterOf($final/100, true);
+    echo "<td>$ep</td>";
     echo "</td><td>$bar</td>";
     echo '</tr>';
 }

--- a/gradesheet.php
+++ b/gradesheet.php
@@ -98,7 +98,7 @@ foreach(fullRoster() as $id=>$details) {
     echo "<td>$section</td>"; // Groups
     echo "<td>$final</td><td>";
     echo letterOf($final/100, true);
-    echo "<td>$ep</td>";
+    echo "<td>".sprintf("%05.2f",$ep*100.0)."</td>";
     echo "</td><td>$bar</td>";
     echo '</tr>';
 }

--- a/gradesheet.php
+++ b/gradesheet.php
@@ -68,8 +68,8 @@ if (!hasFacultyRole($me)) { die("<p>Only faculty may view this page</p></body></
         <th onclick="sortcolumn('tbody',1,true)">Name ⇕</th>
         <th onclick="sortcolumn('tbody',2,true)">Section ⇕</th>
         <th onclick="sortcolumn('tbody',3,true)">Grade ⇕</th>
-        <th onclick="sortcolumn('tbody',4,true)">Earned ⇕</th>
         <th>Letter</th>
+        <th onclick="sortcolumn('tbody',5,true)">Earned ⇕</th>
         <th>Progress</th>
 </tr></thead>
 <tbody id="tbody">

--- a/index.php
+++ b/index.php
@@ -111,7 +111,7 @@ if ($isfaculty && array_key_exists('extension_decision', $_POST)) {
             else if (array_key_exists('late', $_POST) && is_array(json_decode($_POST['late'], true))) 
                 $object['late-policy'] = json_decode($_POST['late'], true);
             $object['close'] = closeTime($object + assignments()[$_POST['extension_assignment']]); // needed to overwrite optional close in assignment itself
-            if ($object['close'] < $object['due']) {
+            if (strtotime($object['close']) < strtotime($object['due'])) {
                 $object['close'] = $object['due'];
             }
             if (!file_put($extendfile, json_encode($object))) preFeedback("Failed to write .extension file");

--- a/index.php
+++ b/index.php
@@ -112,7 +112,7 @@ if ($isfaculty && array_key_exists('extension_decision', $_POST)) {
                 $object['late-policy'] = json_decode($_POST['late'], true);
             $object['close'] = closeTime($object + assignments()[$_POST['extension_assignment']]); // needed to overwrite optional close in assignment itself
             if (date('Y-m-d H:i', $object['close']) < $object['due']) {
-                $object['close'] = $object['due'];
+                $object['close'] = strtotime($object['due']. " America/New_York");
             }
             if (!file_put($extendfile, json_encode($object))) preFeedback("Failed to write .extension file");
             else {

--- a/index.php
+++ b/index.php
@@ -467,7 +467,7 @@ foreach($mine as $slug=>$details) {
             echo 'not submitted';
         else echo 'awaiting feedback';
     } else if ($class == 'pending') echo 'not yet open';
-    else if (!array_key_exists('files', $details)) echo 'submitted elsewhere'; 
+    else if (!array_key_exists('files', $details)) echo 'submission handled elsewhere'; 
     else if (!array_key_exists('.files', $details)) echo 'not yet submitted';
     else if (array_key_exists('autograde', $details)) {
         if ($class == 'late') {

--- a/index.php
+++ b/index.php
@@ -467,7 +467,7 @@ foreach($mine as $slug=>$details) {
             echo 'not submitted';
         else echo 'awaiting feedback';
     } else if ($class == 'pending') echo 'not yet open';
-    else if (!array_key_exists('files', $details)) echo 'not submittable online';
+    else if (!array_key_exists('files', $details)) echo 'submitted elsewhere'; 
     else if (!array_key_exists('.files', $details)) echo 'not yet submitted';
     else if (array_key_exists('autograde', $details)) {
         if ($class == 'late') {

--- a/index.php
+++ b/index.php
@@ -111,6 +111,9 @@ if ($isfaculty && array_key_exists('extension_decision', $_POST)) {
             else if (array_key_exists('late', $_POST) && is_array(json_decode($_POST['late'], true))) 
                 $object['late-policy'] = json_decode($_POST['late'], true);
             $object['close'] = closeTime($object + assignments()[$_POST['extension_assignment']]); // needed to overwrite optional close in assignment itself
+            if ($object['close'] < $object['due']) {
+                $object['close'] = $object['due'];
+            }
             if (!file_put($extendfile, json_encode($object))) preFeedback("Failed to write .extension file");
             else {
                 preFeedback("Recorded new deadline of $object[due] (close time ".prettyTime($object['close']).") for $_POST[extension_assignment]/$_POST[extension_student]");

--- a/index.php
+++ b/index.php
@@ -470,8 +470,12 @@ foreach($mine as $slug=>$details) {
             echo 'not submitted';
         else echo 'awaiting feedback';
     } else if ($class == 'pending') echo 'not yet open';
-    else if (!array_key_exists('files', $details)) echo 'submission handled elsewhere'; 
-    else if (!array_key_exists('.files', $details)) echo 'not yet submitted';
+    else if (!array_key_exists('files', $details)) {
+        if (!array_key_exists('not-submittable-message'))
+            echo 'not submittable online';
+        else
+            echo $details['not-submittable-message'];
+    } else if (!array_key_exists('.files', $details)) echo 'not yet submitted';
     else if (array_key_exists('autograde', $details)) {
         if ($class == 'late') {
             echo 'test cases available';

--- a/index.php
+++ b/index.php
@@ -461,9 +461,9 @@ foreach($mine as $slug=>$details) {
     if (array_key_exists('excused', $details) && $details['excused']) echo 'excused';
     else if (array_key_exists('.ext-req', $details)) echo 'extension requested';
     else if (array_key_exists('.regrade-req', $details)) echo 'request awating review';
+    else if (array_key_exists('grade', $details)) echo 'full feedback available';
     else if ($class == 'closed') {
-        if (array_key_exists('grade', $details)) echo 'full feedback available';
-        else if (array_key_exists('files', $details) && !array_key_exists('.files', $details))
+        if (array_key_exists('files', $details) && !array_key_exists('.files', $details))
             echo 'not submitted';
         else echo 'awaiting feedback';
     } else if ($class == 'pending') echo 'not yet open';

--- a/index.php
+++ b/index.php
@@ -111,7 +111,7 @@ if ($isfaculty && array_key_exists('extension_decision', $_POST)) {
             else if (array_key_exists('late', $_POST) && is_array(json_decode($_POST['late'], true))) 
                 $object['late-policy'] = json_decode($_POST['late'], true);
             $object['close'] = closeTime($object + assignments()[$_POST['extension_assignment']]); // needed to overwrite optional close in assignment itself
-            if (strtotime($object['close']) < strtotime($object['due'])) {
+            if (date('Y-m-d H:i', $object['close']) < $object['due']) {
                 $object['close'] = $object['due'];
             }
             if (!file_put($extendfile, json_encode($object))) preFeedback("Failed to write .extension file");

--- a/task.php
+++ b/task.php
@@ -473,7 +473,7 @@ if ($submitted) {
         if (count($files) - $feedback_count > 1) {
             echo "<p>Older submissions: <ul class='filelist'>";
             foreach($files as $name=>$path) {
-                if (array_key_exists($name, $details['.feedback_files'])) continue;
+                if (array_key_exists($name, $details['.feedback-files'])) continue;
                 if ($name == basename($details['.latest'])) continue;
                 echo "<li>";
                 echo file_download_link($name, $path);

--- a/task.php
+++ b/task.php
@@ -104,6 +104,7 @@ function accept_submission() {
         if (file_exists($linkdir . $name)) {
             rename($linkdir . $name, $linkdir . '.backup-' . $name);
         }
+        file_put($linkdir . '.latest', $fname);
         if (!link($realdir . $name, $linkdir . $name)) {
             user_error_msg("Received <tt>".htmlspecialchars($name)."</tt> but failed to put it into the right location to be tested (not sure why; please report this to your professor).");
             continue;
@@ -201,6 +202,7 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
+            file_put("$dname/.latest", $fname);
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");
         }

--- a/task.php
+++ b/task.php
@@ -225,54 +225,52 @@ if (array_key_exists('submitted', $_GET) && $_GET['submitted']) {
 function show_grade($gradeobj) {
     if (!$gradeobj || !array_key_exists('kind', $gradeobj))
         return "<div class='xp-missed'>It appears the grade data on the server is malformed. Please visit Piazza, search to see if someone else has already reported this, and if not make an open question there identifying the task for which this message appeared.</div>";
-    if ($gradeobj['kind'] == 'percentage') return implode('',array(
-        "<div class='percentage'>",
-        round($gradeobj['ratio']*100, 3),
-        "%</div> <pre>",
-        htmlspecialchars($gradeobj['comments']),
-        "</pre>"
-    ));
     $ans = array();
-    $ans[] = '<table class="feedback"><tbody>';
+    if ($gradeobj['kind'] == 'percentage') {
+	$ans[] = '<table class="feedback"><tbody>';
+	$score = $gradeobj['ratio'];
+    } else {
+	$ans[] = '<table class="feedback"><tbody>';
 
-if ($_SERVER['PHP_AUTH_USER'] == 'lat7h' && false) {
-    preFeedback('');
-    var_dump($gradeobj);
-    leavePre();
-}
+	// correctness
+	if ($gradeobj['auto-weight'] > 0) {
+	    $score = $gradeobj['auto'];
+	    _show_grade_obj_row($ans, $score, "Functional correctness (as determined by test cases)", true);
+	    $lat = array_key_exists('auto-late', $gradeobj) ? $gradeobj['auto-late'] : $score;
+	    if ($lat > $score) {
+		_show_grade_obj_row($ans, $lat, "Late submission functional correctness (as determined by test cases)", true);
+		$pen = array_key_exists('late-penalty', $gradeobj) ? $gradeobj['late-penalty'] : 0.5;
+		$score = $score + ($lat-$score)*$pen;
+	    }
+	    $ans[] = '<tr class="break"><td colspan="2"></td></tr>';
+	} else { $score = 0; }
 
-    // correctness
-    if ($gradeobj['auto-weight'] > 0) {
-        $score = $gradeobj['auto'];
-        _show_grade_obj_row($ans, $score, "Functional correctness (as determined by test cases)", true);
-        $lat = array_key_exists('auto-late', $gradeobj) ? $gradeobj['auto-late'] : $score;
-        if ($lat > $score) {
-            _show_grade_obj_row($ans, $lat, "Late submission functional correctness (as determined by test cases)", true);
-            $pen = array_key_exists('late-penalty', $gradeobj) ? $gradeobj['late-penalty'] : 0.5;
-            $score = $score + ($lat-$score)*$pen;
-        }
-        $ans[] = '<tr class="break"><td colspan="2"></td></tr>';
-    } else { $score = 0; }
-
-    // staff feedback
-    $human = 0;
-    $human_denom = 0;
-    foreach($gradeobj['human'] as $entry) {
-        $r = $entry['ratio'];
-        $human += $entry['weight'] * $r;
-        $human_denom += $entry['weight'];
-        _show_grade_obj_row($ans, $r, $entry['name']);
+	// staff feedback
+	$human = 0;
+	$human_denom = 0;
+	foreach($gradeobj['human'] as $entry) {
+	    $r = $entry['ratio'];
+	    $human += $entry['weight'] * $r;
+	    $human_denom += $entry['weight'];
+	    _show_grade_obj_row($ans, $r, $entry['name']);
+	}
     }
-
     // comment
     if (array_key_exists('comments', $gradeobj))
-        _show_grade_obj_row($ans, false, $gradeobj['comments']);
+	_show_grade_obj_row($ans, false, $gradeobj['comments']);
+
+    if ($gradeobj['kind'] == 'percentage') {
+	_show_grade_obj_row($ans, $score, 'Score before adjustments', true);
+    }
     
     $ans[] = '<tr class="break"><td colspan="2"></td></tr>';
 
     // combined
-    $aw = array_key_exists('auto-weight', $gradeobj) ? $gradeobj['auto-weight'] : 0.5;
-    $score = $human/$human_denom*(1-$aw) + $score*$aw;
+    if ($gradeobj['kind'] == 'percentage') {
+    } else {
+	$aw = array_key_exists('auto-weight', $gradeobj) ? $gradeobj['auto-weight'] : 0.5;
+	$score = $human/$human_denom*(1-$aw) + $score*$aw;
+    }
     if (array_key_exists('.mult', $gradeobj)) {
         // (with multiplier)
         _show_grade_obj_row($ans, $gradeobj['.mult']['ratio'], $gradeobj['.mult']['comments'], true, '× ');
@@ -283,26 +281,32 @@ if ($_SERVER['PHP_AUTH_USER'] == 'lat7h' && false) {
         _show_grade_obj_row($ans, $gradeobj['.adjustment']['mult'], $gradeobj['.adjustment']['comments'], true, '× ');
         $score *= $gradeobj['.adjustment']['mult'];
     }
-    _show_grade_obj_row($ans, $score, 'Overall achievement', true);
+    _show_grade_obj_row($ans, $score, 'Overall score', true);
     
     $ans[] = '</tbody></table>';
     return implode('', $ans);
 }
 function _show_grade_obj_row(&$ans, $ratio, $comment, $percent=False, $prefix='') {
-        $ans[] = '<tr><td class="';
-        $ans[] = $ratio === FALSE ? '' : (($ratio >= 1) ? 'full' : ($ratio > 0 ? 'partial' : 'no'));
-        $ans[] = ' credit">';
-        $ans[] = $prefix;
-        if ($ratio === FALSE) {
-        } else if ($percent) {
+    $ans[] = '<tr>';
+    if ($ratio !== FALSE) {
+	$ans[] = '<td class="';
+	$ans[] = (($ratio >= 1) ? 'full' : ($ratio > 0 ? 'partial' : 'no'));
+	$ans[] = ' credit"';
+	$ans[] = '>';
+	$ans[] = $prefix;
+        if ($percent) {
             $ans[] = round($ratio*100, 1);
             $ans[] = '%';
         } else {
             $ans[] = ($ratio >= 1) ? 'Yes!' : ($ratio > 0 ? 'Kind‑of' : 'No');
         }
-        $ans[] = '</td><td style="white-space: pre-wrap">';
-        $ans[] = htmlspecialchars($comment);
-        $ans[] = '</td></tr>';
+	$ans[] = '</td>';
+	$ans[] = '<td style="white-space: pre-wrap">';
+    } else {
+	$ans[] = '<td style="white-space: pre-wrap; text-align: left" colspan="2">';
+    }
+    $ans[] = htmlspecialchars($comment);
+    $ans[] = '</td></tr>';
 }
 
 

--- a/task.php
+++ b/task.php
@@ -326,6 +326,7 @@ function grader_fb($details) {
     echo '</div></div>';
 }
 function testcase_fb($details) {
+    return;
     if (!array_key_exists('details', $details['autograde']))
         return "Test case listing not enabled for $details[slug]; showing preliminary feedback instead.\n".preliminary_fb($details);
     

--- a/task.php
+++ b/task.php
@@ -413,7 +413,10 @@ if (array_key_exists('link_description', $details)) {
     $link_description = 'Task description';
 }
 
-if (array_key_exists('link', $details))
+if (array_key_exists('describe_html', $details)) {
+    $html = $details['describe_html'];
+    echo "<p>$html</p>";
+} else if (array_key_exists('link', $details))
     if (substr($details['link'],0,2) == '//' || strpos($details['link'], '://') !== FALSE) {
         echo "<p><a href='$details[link]'>$link_description</a>.</p>";
     } else {

--- a/task.php
+++ b/task.php
@@ -445,8 +445,9 @@ if ($submitted) {
     if (array_key_exists('single-file', $details) && $details['single-file'] &&
         array_key_exists('.latest', $details)) {
         $files = $details['.files'];
-        echo "<p>Current submission: ";
+        echo "<p>Current submission: <ul class='filelist'><li>";
         echo file_download_link(basename($details['.latest']), $files[$details['.latest']]);
+        echo "</li></ul>";
         $feedback_count = 0;
         if (array_key_exists('.feedback-files', $details)) {
             $feedback_count = count($details['.feedback-files']);
@@ -461,6 +462,7 @@ if ($submitted) {
             echo "<p>Older submissions: <ul class='filelist'>";
             foreach($files as $name=>$path) {
                 if (array_key_exists($details['.feedback_files'], $name)) continue;
+                if ($name == basename($details['.latest'])) continue;
                 echo "<li>";
                 echo file_download_link($name, $path);
                 echo "</li>";

--- a/task.php
+++ b/task.php
@@ -630,7 +630,8 @@ if ($isfaculty) {
                 $curr = fileinode("uploads/$slug/$user/".basename($f));
                 if ($orig !== FALSE && $orig == $curr) $live[] = basename($f);
                 else $dead[] = $f;
-            }
+	    }
+	    $orig_when = $when;
             $when = substr(basename($when),1);
             echo "<li>".prettyTime(DateTime::createFromFormat('Ymd-His',$when)->getTimestamp());
             if (count($dead)) {
@@ -644,9 +645,9 @@ if ($isfaculty) {
             if (count($live)) {
                  echo " (current copy of <tt>".implode('</tt> and <tt>', $live)."</tt>)";
                  echo " (click to make active version of ";
-                 foreach($dead as $i=>$path) {
+                 foreach($live as $i=>$path) {
                      if ($i != 0) echo " and ";
-                     echo "<button name='make_live' value='$path'>".basename($path)."</button>";
+                     echo "<button name='make_live' value='$orig_when/$path'>".basename($path)."</button>";
                  }
                  echo ")";
             }

--- a/task.php
+++ b/task.php
@@ -440,12 +440,31 @@ if (array_key_exists('no-regrade', $metadata) && array_key_exists($details['grou
     $regradable = $metadata['no-regrade'][$details['group']];
 
 // time category
-$status = ($now < $open) ? 'is not yet open' 
-        :( ($now < $due) ? 'is due ' . prettyTime($due)
-        :( ($now < $close) ? 'was due '.prettyTime($due)
-        :( 'has closed')));
-// time category css class
-$class = ((!$due || $open > $now) ? "pending" : ($due > $now ? "open" : ($close > $now ? "late" : "closed")));
+if (!$due && $now > $close) {
+    $status = 'has closed';
+    $class = 'pending';
+} else if (!$due) {
+    $status = 'is not available';
+    $class = 'pending';
+} else if ($now < $open) {
+    $status = 'is not yet open';
+    $class = 'pending';
+} else if ($now < $due) {
+    $status = 'is due ' . prettyTime($due);
+    $class = 'open';
+} else if ($now < $close) {
+    if (array_key_exists('past_due_message', $metadata)) {
+        $status = 'is due ' . prettyTime($due) . '; you may submit fixes until ' . prettyTime($close);
+    } else {
+        $status = $metadata['past_due_message'];
+        $status = str_replace("DUE_TIME", prettyTime($due), $status);
+        $status = str_replace("CLOSE_TIME", prettyTime($due), $status);
+    }
+    $class = 'late';
+} else {
+    $status = 'has closed';
+    $class = "closed";
+
 
 
 // display basic information

--- a/task.php
+++ b/task.php
@@ -282,12 +282,12 @@ function show_grade($gradeobj) {
         _show_grade_obj_row($ans, $gradeobj['.sub']['portion'], $gradeobj['.sub']['comments'], true, '- ');
         $score -= $gradeobj['.sub']['portion'];
     }
-    if (array_key_exists('.mult', $gradeobj)) {
+    if (array_key_exists('.mult', $gradeobj) && $score > 0.0) {
         // (with multiplier)
         _show_grade_obj_row($ans, $gradeobj['.mult']['ratio'], $gradeobj['.mult']['comments'], true, '× ');
         $score *= $gradeobj['.mult']['ratio'];
     }
-    if (array_key_exists('.adjustment', $gradeobj)) {
+    if (array_key_exists('.adjustment', $gradeobj) && $score > 0.0) {
         // (with multiplier)
         _show_grade_obj_row($ans, $gradeobj['.adjustment']['mult'], $gradeobj['.adjustment']['comments'], true, '× ');
         $score *= $gradeobj['.adjustment']['mult'];

--- a/task.php
+++ b/task.php
@@ -464,7 +464,7 @@ if ($submitted) {
         echo file_download_link(basename($details['.latest']), $files[$details['.latest']]);
         echo "</li></ul>";
         $feedback_count = 0;
-        if (array_key_exists('.feedback-files', $details)) {
+        if (array_key_exists('.feedback-files', $details) && !array_key_exists('withhold', $details)) {
             $feedback_count = count($details['.feedback-files']);
             echo "<p>Grader outputs: <ul class='filelist'>";
             foreach($details['.feedback-files'] as $name=>$path) {

--- a/task.php
+++ b/task.php
@@ -253,9 +253,12 @@ function show_grade($gradeobj) {
 	$human_denom = 0;
 	foreach($gradeobj['human'] as $entry) {
 	    $r = $entry['ratio'];
+            if ($entry['weight'] == 0.0) {
+                continue;
+            }
 	    $human += $entry['weight'] * $r;
 	    $human_denom += $entry['weight'];
-	    _show_grade_obj_row($ans, $r, $entry['name']);
+	    _show_grade_obj_row($ans, $r, $entry['name'] . ' (' . $entry['weight'] . ' points)');
 	}
     }
     // comment
@@ -306,7 +309,15 @@ function _show_grade_obj_row(&$ans, $ratio, $comment, $percent=False, $prefix=''
             $ans[] = round($ratio*100, 1);
             $ans[] = '%';
         } else {
-            $ans[] = ($ratio >= 1) ? 'Yes!' : ($ratio > 0 ? 'Kind‑of' : 'No');
+            if ($ratio == 0.5) {
+                $ans[] = 'Kind-of (half credit)';
+            } else if ($ratio == 0.75) {
+                $ans[] = 'Kind-of (3/4ths credit)';
+            } else if ($ratio == 0.25) {
+                $ans[] = 'Kind-of (1/4ths credit)';
+            } else {
+                $ans[] = ($ratio >= 1) ? 'Yes!' : ($ratio > 0 ? 'Kind‑of' : 'No');
+            }
         }
 	$ans[] = '</td>';
 	$ans[] = '<td style="white-space: pre-wrap">';

--- a/task.php
+++ b/task.php
@@ -253,12 +253,27 @@ function show_grade($gradeobj) {
 	$human_denom = 0;
 	foreach($gradeobj['human'] as $entry) {
 	    $r = $entry['ratio'];
-            if ($entry['weight'] == 0.0) {
+            if ($entry['weight'] == 0.0 && (!array_key_exists('type', $entry) || array_key_exists('sometimes_na', $entry))) {
                 continue;
             }
 	    $human += $entry['weight'] * $r;
 	    $human_denom += $entry['weight'];
-	    _show_grade_obj_row($ans, $r, $entry['name'] . ' (' . $entry['weight'] . ' points)');
+            if ($entry['type'] == 'points') {
+                _show_grade_obj_points($ans, $r, $entry['weight'], $entry['name']);
+            } else if ($entry['type'] == 'comment') {
+            } else {
+                if ($entry['weight'] == 0) {
+                    _show_grade_obj_row($ans, $r, $entry['name'] . ' (not part of grade)');
+                } else {
+                    _show_grade_obj_row($ans, $r, $entry['name'] . ' (' . $entry['weight'] . ' points)');
+                }
+            }
+            if (array_key_exists('comment', $entry) && strlen($entry['comment']) > 0) {
+                _show_grade_obj_row($ans, false, $entry['comment']);
+            }
+            if (array_key_exists('comments', $entry) && strlen($entry['comments']) > 0) {
+                _show_grade_obj_row($ans, false, $entry['comments']);
+            }
 	}
     }
     // comment
@@ -296,6 +311,21 @@ function show_grade($gradeobj) {
     
     $ans[] = '</tbody></table>';
     return implode('', $ans);
+}
+
+function _show_grade_obj_points(&$ans, $ratio, $weight, $comment) {
+    $ans[] = '<tr>';
+    $ans[] = '<td class="';
+    $ans[] = (($ratio >= 1) ? 'full' : ($ratio > 0 ? 'partial' : 'no'));
+    $ans[] = ' credit"';
+    $ans[] = '>';
+    $points = round($ratio * $weight, 1);
+    $of_points = round($weight, 1);
+    $ans[] = "$points / $of_points";
+    $ans[] = '</td>';
+    $ans[] = '<td style="white-space: pre-wrap">';
+    $ans[] = htmlspecialchars($comment);
+    $ans[] = '</td></tr>';
 }
 function _show_grade_obj_row(&$ans, $ratio, $comment, $percent=False, $prefix='') {
     $ans[] = '<tr>';

--- a/task.php
+++ b/task.php
@@ -442,13 +442,39 @@ function file_download_link($name, $path) {
 // display submission status
 echo '<div class="submissions">';
 if ($submitted) {
-    echo "Your files (<a href='view.php?file=$slug/$user$ext'>view all</a>) (<a href='download.php?file=$slug/$user$ext'>download all as .zip</a>):<ul class='filelist'>";
-    foreach($details['.files'] as $name=>$path) {
-        echo "<li>";
-        echo file_download_link($name, $path);
-        echo "</li>";
+    if (array_key_exists('single-file', $details) && $details['single-file'] &&
+        array_key_exists('.latest', $details)) {
+        echo "<p>Current submission: ";
+        echo file_download_link($name, $details['.latest']);
+        $feedback_count = 0;
+        if (array_key_exists('.feedback-files', $details)) {
+            $feedback_count = count($details['.feedback-files']);
+            echo "<p>Grader outputs: <ul class='filelist'>";
+            foreach($details['.feedback-files'] as $name=>$path) {
+                echo "<li>";
+                echo file_download_link($name, $path);
+                echo "</li>";
+            }
+        }
+        if (count($details['.files']) - $feedback_count > 1) {
+            echo "<p>Older submissions: <ul class='filelist'>";
+            foreach($details['.files'] as $name=>$path) {
+                if (array_key_exists($details['.feedback_files'], $name)) continue;
+                echo "<li>";
+                echo file_download_link($name, $path);
+                echo "</li>";
+            }
+            echo "</ul>";
+        }
+    } else {
+        echo "Your files (<a href='view.php?file=$slug/$user$ext'>view all</a>) (<a href='download.php?file=$slug/$user$ext'>download all as .zip</a>):<ul class='filelist'>";
+        foreach($details['.files'] as $name=>$path) {
+            echo "<li>";
+            echo file_download_link($name, $path);
+            echo "</li>";
+        }
+        echo '</ul>';
     }
-    echo '</ul>';
 } else if (array_key_exists('files', $details)) {
     echo 'You have not yet submitted this assignment.';
 } else {

--- a/task.php
+++ b/task.php
@@ -104,7 +104,7 @@ function accept_submission() {
         if (file_exists($linkdir . $name)) {
             rename($linkdir . $name, $linkdir . '.backup-' . $name);
         }
-        file_put($linkdir . '.latest', $fname);
+        file_put($linkdir . '.latest', $fname . "\n" . $now);
         if (!link($realdir . $name, $linkdir . $name)) {
             user_error_msg("Received <tt>".htmlspecialchars($name)."</tt> but failed to put it into the right location to be tested (not sure why; please report this to your professor).");
             continue;
@@ -202,7 +202,7 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
-            file_put("$dname/.latest", $fname);
+            file_put("$dname/.latest", $fname . "\n" .dirname($_POST['make_live']));
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");
         }
@@ -444,8 +444,9 @@ echo '<div class="submissions">';
 if ($submitted) {
     if (array_key_exists('single-file', $details) && $details['single-file'] &&
         array_key_exists('.latest', $details)) {
+        $files = $details['.files']
         echo "<p>Current submission: ";
-        echo file_download_link($name, $details['.latest']);
+        echo file_download_link(basename($details['.latest']), $files[$details['.latest']]);
         $feedback_count = 0;
         if (array_key_exists('.feedback-files', $details)) {
             $feedback_count = count($details['.feedback-files']);
@@ -456,9 +457,9 @@ if ($submitted) {
                 echo "</li>";
             }
         }
-        if (count($details['.files']) - $feedback_count > 1) {
+        if (count($files) - $feedback_count > 1) {
             echo "<p>Older submissions: <ul class='filelist'>";
-            foreach($details['.files'] as $name=>$path) {
+            foreach($files as $name=>$path) {
                 if (array_key_exists($details['.feedback_files'], $name)) continue;
                 echo "<li>";
                 echo file_download_link($name, $path);

--- a/task.php
+++ b/task.php
@@ -202,7 +202,7 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
-            $dname_no_dot = substr($dname, 0, 1);
+            $dname_no_dot = substr($dname, 1);
             file_put("$dname/.latest", $fname . "\n" .$dname_no_dot);
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");

--- a/task.php
+++ b/task.php
@@ -505,7 +505,8 @@ echo '</div>';
 // display feedback
 if ((($due < $now) || ($isstaff && $isself))
 && array_key_exists('grade', $details)
-&& !array_key_exists('.ext-req', $details)) {
+&& !array_key_exists('.ext-req', $details)
+&& !array_key_exists('withhold', $details)) {
     grader_fb($details);
 } else if (array_key_exists('.files', $details)) {
     if (($due < $now)

--- a/task.php
+++ b/task.php
@@ -202,8 +202,8 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
-            $dname_no_dot = substr(basename($dname), 1);
-            file_put("$dname/.latest", $fname . "\n" .$dname_no_dot);
+            $stamp = substr(basename(dirname($_POST['make_live'])), 1);
+            file_put("$dname/.latest", $fname . "\n" .$stamp);
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");
         }

--- a/task.php
+++ b/task.php
@@ -472,8 +472,8 @@ echo "<h1>$slug – ";
 if (array_key_exists('title', $details)) echo $details['title'];
 echo "</h1>";
 
-if (array_key_exists('link_description', $details)) {
-    $link_description = $details['link_description'];
+if (array_key_exists('link-description', $details)) {
+    $link_description = $details['link-description'];
 } else {
     $link_description = 'Task description';
 }

--- a/task.php
+++ b/task.php
@@ -492,7 +492,6 @@ if ($submitted) {
 } else if (array_key_exists('files', $details)) {
     echo 'You have not yet submitted this assignment.';
 } else {
-    echo "<p>Online submissions are not enabled for this assignment.</p>";
 }
 echo '</div>';
 

--- a/task.php
+++ b/task.php
@@ -602,7 +602,7 @@ if ($submittable) {
         echo " ($user)";
     }
     if ($class == 'late') {
-	if (array_key_exists('late-policy', $details)) {
+	if (array_key_exists('show-late-estimate-on-submit', $metadata) && $metadata['show-late-estimate-on-submit'] && array_key_exists('late-policy', $details)) {
 	    $late_days = (time() - assignmentTime('due', $details) + 60) / (60 * 60 * 24);
 	    $late_days = floor($late_days);
 	    $late_days_p1 = $late_days + 1;

--- a/task.php
+++ b/task.php
@@ -202,7 +202,7 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
-            $dname_no_dot = substr($dname, 1);
+            $dname_no_dot = substr(basename($dname), 1);
             file_put("$dname/.latest", $fname . "\n" .$dname_no_dot);
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");

--- a/task.php
+++ b/task.php
@@ -253,23 +253,22 @@ function show_grade($gradeobj) {
 	$human_denom = 0;
 	foreach($gradeobj['human'] as $entry) {
 	    $r = $entry['ratio'];
-            if ($entry['weight'] == 0.0 && (!array_key_exists('type', $entry) || array_key_exists('sometimes_na', $entry))) {
+            if ($entry['weight'] == 0.0 && array_key_exists('sometimes_na', $entry)) {
                 continue;
             }
 	    $human += $entry['weight'] * $r;
 	    $human_denom += $entry['weight'];
-            if ($entry['type'] == 'points') {
+            if ($entry['kind'] == 'points') {
                 _show_grade_obj_points($ans, $r, $entry['weight'], $entry['name']);
-            } else if ($entry['type'] == 'comment') {
-            } else {
+            } else if ($entry['kind'] == 'comment') {
+            } else if (getShowPointsOption()) {
                 if ($entry['weight'] == 0) {
                     _show_grade_obj_row($ans, $r, $entry['name'] . ' (not part of grade)');
                 } else {
                     _show_grade_obj_row($ans, $r, $entry['name'] . ' (' . $entry['weight'] . ' points)');
                 }
-            }
-            if (array_key_exists('comment', $entry) && strlen($entry['comment']) > 0) {
-                _show_grade_obj_row($ans, false, $entry['comment']);
+            } else {
+                _show_grade_obj_row($ans, $r, $entry['name']);
             }
             if (array_key_exists('comments', $entry) && strlen($entry['comments']) > 0) {
                 _show_grade_obj_row($ans, false, $entry['comments']);

--- a/task.php
+++ b/task.php
@@ -273,6 +273,11 @@ function show_grade($gradeobj) {
 	$aw = array_key_exists('auto-weight', $gradeobj) ? $gradeobj['auto-weight'] : 0.5;
 	$score = $human/$human_denom*(1-$aw) + $score*$aw;
     }
+    if (array_key_exists('.sub', $gradeobj)) {
+        // (with subtraction)
+        _show_grade_obj_row($ans, $gradeobj['.sub']['portion'], $gradeobj['.sub']['comments'], true, '- ');
+        $score -= $gradeobj['.sub']['portion'];
+    }
     if (array_key_exists('.mult', $gradeobj)) {
         // (with multiplier)
         _show_grade_obj_row($ans, $gradeobj['.mult']['ratio'], $gradeobj['.mult']['comments'], true, '× ');
@@ -438,6 +443,12 @@ function file_download_link($name, $path) {
     return "<a title='$name' href='download.php?file=$dl'>$name</a> $mtime";
 }
 
+function file_view_link($name, $path) {
+    $dl = rawurlencode(explode('/',$path,2)[1]);
+    $mtime = prettyTime(filemtime($path));
+    return "<a title='view $name' href='view.php?file=$dl'>(view)</a>";
+}
+
 
 // display submission status
 echo '<div class="submissions">';
@@ -454,7 +465,7 @@ if ($submitted) {
             echo "<p>Grader outputs: <ul class='filelist'>";
             foreach($details['.feedback-files'] as $name=>$path) {
                 echo "<li>";
-                echo file_download_link($name, $path);
+                echo file_download_link($name, $path) . " " . file_view_link($name, $path);
                 echo "</li>";
             }
         }

--- a/task.php
+++ b/task.php
@@ -226,6 +226,7 @@ if (array_key_exists('submitted', $_GET) && $_GET['submitted']) {
 
 
 function show_grade($gradeobj) {
+    global $metadata;
     if (!$gradeobj || !array_key_exists('kind', $gradeobj))
         return "<div class='xp-missed'>It appears the grade data on the server is malformed. Please visit Piazza, search to see if someone else has already reported this, and if not make an open question there identifying the task for which this message appeared.</div>";
     $ans = array();
@@ -279,10 +280,10 @@ function show_grade($gradeobj) {
     if (array_key_exists('comments', $gradeobj))
 	_show_grade_obj_row($ans, false, $gradeobj['comments']);
 
-    if ($gradeobj['kind'] == 'percentage') {
+    if (array_key_exists('show-score-before-adjustments', $metadata) && $metadata['show-score-before-adjustments']) {
 	_show_grade_obj_row($ans, $score, 'Score before adjustments', true);
     }
-    
+
     $ans[] = '<tr class="break"><td colspan="2"></td></tr>';
 
     // combined

--- a/task.php
+++ b/task.php
@@ -391,7 +391,6 @@ $show_cases =  $due < $now
     && !array_key_exists('.ext-req', $details);
 $extendable = ($now < $due || !$submitted) 
     && array_key_exists('files', $details) 
-    && !array_key_exists('.files', $details) 
     && !(array_key_exists('no-extension', $metadata) && array_key_exists($details['group'], $metadata['no-extension']));
 
 $regradable = TRUE;

--- a/task.php
+++ b/task.php
@@ -202,7 +202,8 @@ function roll_back() {
             if (file_exists("$dname/.autograde")) unlink("$dname/.autograde");
             if (file_exists("$dname/.grade")) unlink("$dname/.grade");
             link($_POST['make_live'], "$dname/$fname");
-            file_put("$dname/.latest", $fname . "\n" .dirname($_POST['make_live']));
+            $dname_no_dot = substr($dname, 0, 1);
+            file_put("$dname/.latest", $fname . "\n" .$dname_no_dot);
             ensure_file("meta/queued/$slug-$user", basename($dname));
             user_success_msg("roll-back completed: <tt>$dname/$fname</tt> now aliases <tt>$_POST[make_live]</tt>, any previous feedback has been removed, and the autograder has been queued to review <tt>meta/queued/$slug-$user</tt>.");
         }

--- a/task.php
+++ b/task.php
@@ -453,10 +453,10 @@ if (!$due && $now > $close) {
     $status = 'is due ' . prettyTime($due);
     $class = 'open';
 } else if ($now < $close) {
-    if (array_key_exists('past_due_message', $metadata)) {
+    if (array_key_exists('past-due-message', $metadata)) {
         $status = 'is due ' . prettyTime($due) . '; you may submit fixes until ' . prettyTime($close);
     } else {
-        $status = $metadata['past_due_message'];
+        $status = $metadata['past-due-message'];
         $status = str_replace("DUE_TIME", prettyTime($due), $status);
         $status = str_replace("CLOSE_TIME", prettyTime($due), $status);
     }

--- a/task.php
+++ b/task.php
@@ -468,11 +468,12 @@ if ($submitted) {
                 echo file_download_link($name, $path) . " " . file_view_link($name, $path);
                 echo "</li>";
             }
+            echo "</ul>";
         }
         if (count($files) - $feedback_count > 1) {
             echo "<p>Older submissions: <ul class='filelist'>";
             foreach($files as $name=>$path) {
-                if (array_key_exists($details['.feedback_files'], $name)) continue;
+                if (in_array($details['.feedback_files'], $name)) continue;
                 if ($name == basename($details['.latest'])) continue;
                 echo "<li>";
                 echo file_download_link($name, $path);

--- a/task.php
+++ b/task.php
@@ -394,7 +394,7 @@ if (array_key_exists('no-regrade', $metadata) && array_key_exists($details['grou
 // time category
 $status = ($now < $open) ? 'is not yet open' 
         :( ($now < $due) ? 'is due ' . prettyTime($due)
-        :( ($now < $close) ? 'was due '.prettyTime($due).'; you may submit fixes until ' . prettyTime($close) 
+        :( ($now < $close) ? 'was due '.prettyTime($due)
         :( 'has closed')));
 // time category css class
 $class = ((!$due || $open > $now) ? "pending" : ($due > $now ? "open" : ($close > $now ? "late" : "closed")));
@@ -489,10 +489,23 @@ if ($submittable) {
         echo rosterEntry($user)['name'];
         echo " ($user)";
     }
-    if ($class == 'late')
-        echo ", though it is now late (see the course syllabus for details on what that means)";
+    if ($class == 'late') {
+	if (array_key_exists('late-policy', $details)) {
+	    $late_days = (time() - assignmentTime('due', $details) + 60) / (60 * 60 * 24);
+	    $late_days = floor($late_days);
+	    $late_days_p1 = $late_days + 1;
+	    $late_policy = $details['late-policy'];
+	    if ($late_days >= count($late_policy)) {
+		$late_days = count($late_policy) - 1;
+	    }
+	    $penalty = $late_policy[$late_days];
+	    $penalty_percent = floor($penalty * 100.0);
+	    echo ", though it is now late (estimated $penalty_percent% credit for $late_days_p1 day late submission)";
+	} else {
+	    echo ", though it is now late (see the course syllabus for what that means)";
+	}
+    }
     echo ":</p><center><input type='file' multiple='multiple' name='submission[]'/><input type='submit' name='upload' value='Upload file(s)'/></center></form>";
-    
 }
 
 

--- a/task.php
+++ b/task.php
@@ -401,20 +401,26 @@ echo "<h1>$slug – ";
 if (array_key_exists('title', $details)) echo $details['title'];
 echo "</h1>";
 
+if (array_key_exists('link_description', $details)) {
+    $link_description = $details['link_description'];
+} else {
+    $link_description = 'Task description';
+}
+
 if (array_key_exists('link', $details))
     if (substr($details['link'],0,2) == '//' || strpos($details['link'], '://') !== FALSE) {
-        echo "<p><a href='$details[link]'>Task description</a>.</p>";
+        echo "<p><a href='$details[link]'>$link_description</a>.</p>";
     } else {
-        echo "<p><a href='$metadata[writeup_prefix]$details[link]'>Task description</a>.</p>";
+        echo "<p><a href='$metadata[writeup_prefix]$details[link]'>$link_description</a>.</p>";
     }
 else if (array_key_exists('writeup', $details))
-    echo "<p><a href='$metadata[writeup_prefix]$details[writeup]'>Task description</a>.</p>";
+    echo "<p><a href='$metadata[writeup_prefix]$details[writeup]'>$link_description</a>.</p>";
 else if (array_key_exists('title', $details)) {
     echo "<p><a href='$metadata[writeup_prefix]";
     echo strtolower($slug);
     echo "-";
     echo strtolower($details['title']);
-    echo ".html'>Task description</a>.</p>";
+    echo ".html'>$link_description</a>.</p>";
 }
 echo "<p>Return to <a href='index.php$end'>Assignments list</a> or <a href='$metadata[url]'>main course page</a>.</p>";
 

--- a/task.php
+++ b/task.php
@@ -444,7 +444,7 @@ echo '<div class="submissions">';
 if ($submitted) {
     if (array_key_exists('single-file', $details) && $details['single-file'] &&
         array_key_exists('.latest', $details)) {
-        $files = $details['.files']
+        $files = $details['.files'];
         echo "<p>Current submission: ";
         echo file_download_link(basename($details['.latest']), $files[$details['.latest']]);
         $feedback_count = 0;

--- a/task.php
+++ b/task.php
@@ -447,7 +447,7 @@ echo '</div>';
 
 
 // display feedback
-if ((($close < $now) || ($isstaff && $isself))
+if ((($due < $now) || ($isstaff && $isself))
 && array_key_exists('grade', $details)
 && !array_key_exists('.ext-req', $details)) {
     grader_fb($details);

--- a/task.php
+++ b/task.php
@@ -643,6 +643,12 @@ if ($isfaculty) {
             }
             if (count($live)) {
                  echo " (current copy of <tt>".implode('</tt> and <tt>', $live)."</tt>)";
+                 echo " (click to make active version of ";
+                 foreach($dead as $i=>$path) {
+                     if ($i != 0) echo " and ";
+                     echo "<button name='make_live' value='$path'>".basename($path)."</button>";
+                 }
+                 echo ")";
             }
             echo "</li>";
             

--- a/task.php
+++ b/task.php
@@ -473,7 +473,7 @@ if ($submitted) {
         if (count($files) - $feedback_count > 1) {
             echo "<p>Older submissions: <ul class='filelist'>";
             foreach($files as $name=>$path) {
-                if (in_array($details['.feedback_files'], $name)) continue;
+                if (array_key_exists($name, $details['.feedback_files'])) continue;
                 if ($name == basename($details['.latest'])) continue;
                 echo "<li>";
                 echo file_download_link($name, $path);

--- a/tools.php
+++ b/tools.php
@@ -768,6 +768,24 @@ function asgn_details($student, $slug) {
         if ($t > $sentin) $sentin = $t;
     }
     $details['submitted'] = $sentin;
+    $late_days = ($sentin - assignmentTime('due', $details)) / (60 * 60 * 24);
+    $details['submitted-late-days'] = $late_days;
+    if ($late_days > -1 && array_key_exists('late-policy', $details)) {
+	$late_policy = $details['late-policy'];
+	$late_days = floor($late_days);
+	$late_days_p1 = $late_days + 1;
+	if ($late_days >= count($late_policy)) {
+	    $late_days = count($late_policy) - 1;
+	}
+	$details['policy-late-penalty'] = $late_policy[$late_days];
+	if (array_key_exists('grade', $details)) {
+	    $details['grade']['.mult'] = array(
+		'kind' => 'percentage',
+		'ratio' => $details['policy-late-penalty'],
+		'comments' => "$late_days_p1 days late",
+	    );
+	}
+    }
 
     // add download links for current submissions
     $files = array();

--- a/tools.php
+++ b/tools.php
@@ -784,7 +784,7 @@ function asgn_details($student, $slug) {
         $t = filemtime($path);
         if ($t > $sentin) $sentin = $t;
     }
-    if (file_exists("uploads/$slug/$student/.latest")) {
+    if (array_key_exists('single-file', $details) && $details['single-file'] && file_exists("uploads/$slug/$student/.latest")) {
         $latest_lines = explode("\n",trim(file_get_contents("uploads/$slug/$student/.latest")));
         $details['.latest'] = $latest_lines[0];
         $details['.latest-subdir'] = $latest_lines[1];

--- a/tools.php
+++ b/tools.php
@@ -794,6 +794,10 @@ function asgn_details($student, $slug) {
     foreach(glob("uploads/$slug/$student/*") as $path) {
         $files[basename($path)] = $path;
     }
+
+    if (file_exists("uploads/$slug/$student/.latest"))
+        $details['.latest'] = file_get_contents("uploads/$slug/$student/.latest");
+
     if (array_key_exists('extends', $details)) {
         foreach($details['extends'] as $slug2) {
             foreach(glob("uploads/$slug2/$student/*") as $path) {

--- a/tools.php
+++ b/tools.php
@@ -1066,7 +1066,7 @@ function score_of_task($details) {
     if (!$gradeobj || !array_key_exists('kind', $gradeobj)) return NAN;
     if ($gradeobj['kind'] == 'percentage') {
 	$score = $gradeobj['ratio'];
-	if (array_key_exists('.mult', $gradeobj)) {
+	if (array_key_exists('.mult', $gradeobj) && $score > 0.0) {
 	    // (with multiplier)
 	    $score *= $gradeobj['.mult']['ratio'];
 	}
@@ -1106,7 +1106,7 @@ function score_of_task($details) {
         // (with subtraction)
         $score -= $gradeobj['.sub']['portion'];
     }
-    if (array_key_exists('.mult', $gradeobj)) {
+    if (array_key_exists('.mult', $gradeobj) && $score > 0.0) {
         // (with multiplier)
         $score *= $gradeobj['.mult']['ratio'];
     }

--- a/tools.php
+++ b/tools.php
@@ -757,9 +757,11 @@ function asgn_details($student, $slug) {
     // add submission time
     $sentin = 0;
     foreach(glob("uploads/$slug/$student/*") as $path) {
-        $finfo = new finfo(FILEINFO_MIME);
-        $mime = $finfo->file($path);
-        if (stripos($mime, 'image') !== FALSE) { continue; }
+        if (array_key_exists('feedback-files', $details)) {
+            foreach($details['feedback-files'] as $pattern) {
+                if (fnmatch($pattern, $name, FNM_PERIOD)) continue;
+            }
+        }
         $t = filemtime($path);
         if ($t > $sentin) $sentin = $t;
     }

--- a/tools.php
+++ b/tools.php
@@ -67,18 +67,21 @@ function rosterEntry($id, $check=false) {
 }
 
 $_assignments = False;
+$_all_assignments = False;
+function _filter_hidden($entry) { return !array_key_exists("hide", $entry) || !$entry["hide"]; }
 /// Helper function to read the set of assignments (needed in almost every view)
-function assignments() {
-    global $_assignments, $metadata;
+function assignments($showhidden=false) {
+    global $_assignments, $_all_assignments, $metadata;
     if ($_assignments === False) {
-        $_assignments = json_decode(file_get_contents("meta/assignments.json"), true);
-        foreach($_assignments as $k=>$v) {
+        $_all_assignments = json_decode(file_get_contents("meta/assignments.json"), true);
+        foreach($_all_assignments as $k=>$v) {
             if (!array_key_exists('fbdelay', $v)) {
-                $_assignments[$k]['fbdelay'] = array_key_exists('fbdelay', $metadata) ? $metadata['fbdelay'] : 2;
+                $_all_assignments[$k]['fbdelay'] = array_key_exists('fbdelay', $metadata) ? $metadata['fbdelay'] : 2;
             }
         }
+        $_assignments = array_filter($_all_assignments, _filter_hidden);
     }
-    return $_assignments;
+    return $showhidden ? $_all_assignments : $_assignments;
 }
 
 $_coursegrade = False;

--- a/tools.php
+++ b/tools.php
@@ -591,7 +591,7 @@ function rubricOf($slug) {
     if (array_key_exists($slug, $aset) && array_key_exists('rubric', $aset[$slug]))
         $rubric = $aset[$slug]['rubric'];
     else if (file_exists("uploads/$slug/.rubric"))
-        $rubric = json_decode(file_get_contents("uploads/$slug/.rubric"), true);
+	$rubric = json_decode(file_get_contents("uploads/$slug/.rubric"), true);
     else if (file_exists("uploads/.rubric"))
         $rubric = json_decode(file_get_contents("uploads/.rubric"), true);
     else if (file_exists("meta/rubric.json"))

--- a/tools.php
+++ b/tools.php
@@ -791,12 +791,17 @@ function asgn_details($student, $slug) {
 
     // add download links for current submissions
     $files = array();
+    $feedback_files = array()
     foreach(glob("uploads/$slug/$student/*") as $path) {
         $files[basename($path)] = $path;
+        if (array_key_exists('feedback-files', $details)) {
+            foreach($details['feedback-files'] as $pattern) {
+                if (fnmatch($pattern, basename($path), FNM_PERIOD)) {
+                    $feedback_files[basename($path)] = $path;
+                }
+            }
+        }
     }
-
-    if (file_exists("uploads/$slug/$student/.latest"))
-        $details['.latest'] = file_get_contents("uploads/$slug/$student/.latest");
 
     if (array_key_exists('extends', $details)) {
         foreach($details['extends'] as $slug2) {
@@ -810,6 +815,13 @@ function asgn_details($student, $slug) {
     natcasesort($files);
     if (count($files) > 0)
         $details['.files'] = $files;
+
+    if (count($feedback_files) > 0)
+        $details['.feedback-files'] = $feedback_files;
+
+    if (file_exists("uploads/$slug/$student/.latest")) {
+        $details['.latest'] = file_get_contents("uploads/$slug/$student/.latest");
+    }
     
     // add lists of partners
     $partners = array();

--- a/tools.php
+++ b/tools.php
@@ -791,7 +791,7 @@ function asgn_details($student, $slug) {
 
     // add download links for current submissions
     $files = array();
-    $feedback_files = array()
+    $feedback_files = array();
     foreach(glob("uploads/$slug/$student/*") as $path) {
         $files[basename($path)] = $path;
         if (array_key_exists('feedback-files', $details)) {

--- a/tools.php
+++ b/tools.php
@@ -722,6 +722,8 @@ function asgn_details($student, $slug) {
     }
     if (file_exists("uploads/$slug/$student/.grade"))
         $details['grade'] = json_decode(file_get_contents("uploads/$slug/$student/.grade"), TRUE);
+    if (file_exists("uploads/$slug/$student/.gradetemplate"))
+	$details['grade_template'] = json_decode(file_get_contents("uploads/$slug/$student/.gradetemplate"), TRUE);
     if (file_exists("uploads/$slug/$student/.autograde")) {
         $details['autograde'] = json_decode(file_get_contents("uploads/$slug/$student/.autograde"), TRUE);
         $details['autograde']['created'] = filemtime("uploads/$slug/$student/.autograde");

--- a/tools.php
+++ b/tools.php
@@ -759,7 +759,7 @@ function asgn_details($student, $slug) {
     foreach(glob("uploads/$slug/$student/*") as $path) {
         if (array_key_exists('feedback-files', $details)) {
             foreach($details['feedback-files'] as $pattern) {
-                if (fnmatch($pattern, $name, FNM_PERIOD)) continue;
+                if (fnmatch($pattern, basename($path), FNM_PERIOD)) continue;
             }
         }
         $t = filemtime($path);
@@ -768,21 +768,23 @@ function asgn_details($student, $slug) {
     $details['submitted'] = $sentin;
     $late_days = ($sentin - assignmentTime('due', $details)) / (60 * 60 * 24);
     $details['submitted-late-days'] = $late_days;
-    if ($late_days > -1 && array_key_exists('late-policy', $details)) {
+    if ($late_days > 0 && array_key_exists('late-policy', $details)) {
 	$late_policy = $details['late-policy'];
-	$late_days = floor($late_days);
-	$late_days_p1 = $late_days + 1;
-	if ($late_days >= count($late_policy)) {
-	    $late_days = count($late_policy) - 1;
-	}
-	$details['policy-late-penalty'] = $late_policy[$late_days];
-	if (array_key_exists('grade', $details)) {
-	    $details['grade']['.mult'] = array(
-		'kind' => 'percentage',
-		'ratio' => $details['policy-late-penalty'],
-		'comments' => "$late_days_p1 days late",
-	    );
-	}
+        if (count($late_policy) > 0) {
+            $late_days = floor($late_days);
+            $late_days_p1 = $late_days + 1;
+            if ($late_days >= count($late_policy)) {
+                $late_days = count($late_policy) - 1;
+            }
+            $details['policy-late-penalty'] = $late_policy[$late_days];
+            if (array_key_exists('grade', $details)) {
+                $details['grade']['.mult'] = array(
+                    'kind' => 'percentage',
+                    'ratio' => $details['policy-late-penalty'],
+                    'comments' => "$late_days_p1 days late",
+                );
+            }
+        }
     }
 
     // add download links for current submissions

--- a/tools.php
+++ b/tools.php
@@ -934,7 +934,7 @@ function cumulative_status($student, &$progress=False, &$projected_score=False) 
         }
         
         // record submission
-        $earned = score_of_task($details['grade']);
+        $earned = score_of_task($details);
         $details['.score'] = $earned;
         $ans[$details['group']]['past'][] = array('slug'=>$slug, 'got'=>$earned*$details['weight'], 'of'=>$details['weight']);
         $gcode[] = 'graded';
@@ -1026,9 +1026,21 @@ function cumulative_status($student, &$progress=False, &$projected_score=False) 
 
  */
 
-function score_of_task($gradeobj) {
+function score_of_task($details) {
+    $gradeobj = $details['grade'];
     if (!$gradeobj || !array_key_exists('kind', $gradeobj)) return NAN;
-    if ($gradeobj['kind'] == 'percentage') return $gradeobj['ratio'];
+    if ($gradeobj['kind'] == 'percentage') {
+	$score = $gradeobj['ratio'];
+	if (array_key_exists('.mult', $gradeobj)) {
+	    // (with multiplier)
+	    $score *= $gradeobj['.mult']['ratio'];
+	}
+	if (array_key_exists('.adjustment', $gradeobj)) {
+	    // (with multiplier)
+	    $score *= $gradeobj['.adjustment']['mult'];
+	}
+	return $score;
+    }
 
     // correctness
     $score = $gradeobj['auto'];

--- a/tools.php
+++ b/tools.php
@@ -622,7 +622,7 @@ function studentFileTag($path, $classes='left') {
         if (stripos($mime, 'image') !== FALSE) {
             return "<a href='$link' target='_blank'><img class='$classes width height' src='$link'/></a><br/><input type='button' value='toggle image visibility' onclick='e=this.previousSibling.previousSibling; e.setAttribute(\"style\", e.getAttribute(\"style\") ? \"\" : \"display:none\")'/>";
             //  return "<a href='$link' target='_blank'><img class='$classes width height' src='$link'/></a>";
-        } else if (stripos($mime, 'text') !== FALSE) {
+        } else if (stripos($mime, 'text') !== FALSE && filesize($path) < 4 * 1024 * 1024) {
             $contents = file_get_contents($path);
             $contents = preg_replace('/[^\n\r \t!-~]/', '', $contents);
             return "<div class='$classes width'>File <a href='$link' target='_blank'><tt>$title</tt></a>: <input type='button' style='font-family:monospace' value='toggle visibility' onclick='e=this.nextSibling; e.setAttribute(\"style\", e.getAttribute(\"style\") ? \"\" : \"display:none\")'/><pre><code>" . htmlspecialchars($contents) . "</code></pre></div>";

--- a/tools.php
+++ b/tools.php
@@ -634,7 +634,7 @@ function studentFileTag($path, $classes='left') {
         if (stripos($mime, 'image') !== FALSE) {
             return "<a href='$link' target='_blank'><img class='$classes width height' src='$link'/></a><br/><input type='button' value='toggle image visibility' onclick='e=this.previousSibling.previousSibling; e.setAttribute(\"style\", e.getAttribute(\"style\") ? \"\" : \"display:none\")'/>";
             //  return "<a href='$link' target='_blank'><img class='$classes width height' src='$link'/></a>";
-        } else if (stripos($mime, 'text') !== FALSE && filesize($path) < 4 * 1024 * 1024) {
+        } else if (stripos($mime, 'text') !== FALSE && filesize($path) < 1 * 1024 * 1024) {
             $contents = file_get_contents($path);
             $contents = preg_replace('/[^\n\r \t!-~]/', '', $contents);
             return "<div class='$classes width'>File <a href='$link' target='_blank'><tt>$title</tt></a>: <input type='button' style='font-family:monospace' value='toggle visibility' onclick='e=this.nextSibling; e.setAttribute(\"style\", e.getAttribute(\"style\") ? \"\" : \"display:none\")'/><pre><code>" . htmlspecialchars($contents) . "</code></pre></div>";

--- a/tools.php
+++ b/tools.php
@@ -793,6 +793,7 @@ function asgn_details($student, $slug) {
                     $details['grade']['.adjustment'] = array(
                         'kind' => 'percentage',
                         'ratio' => $details['policy-late-penalty'],
+                        'mult' => $details['policy-late-penalty'], # FIXME: duplicated?
                         'comments' => "$late_days_p1 days late",
                     );
                 }

--- a/tools.php
+++ b/tools.php
@@ -1070,7 +1070,7 @@ function score_of_task($details) {
 	    // (with multiplier)
 	    $score *= $gradeobj['.mult']['ratio'];
 	}
-	if (array_key_exists('.adjustment', $gradeobj)) {
+	if (array_key_exists('.adjustment', $gradeobj) && $score > 0.0) {
 	    // (with multiplier)
 	    $score *= $gradeobj['.adjustment']['mult'];
 	}
@@ -1110,7 +1110,7 @@ function score_of_task($details) {
         // (with multiplier)
         $score *= $gradeobj['.mult']['ratio'];
     }
-    if (array_key_exists('.adjustment', $gradeobj)) {
+    if (array_key_exists('.adjustment', $gradeobj) && $score > 0.0) {
         // (with multiplier)
         $score *= $gradeobj['.adjustment']['mult'];
     }

--- a/tools.php
+++ b/tools.php
@@ -1086,6 +1086,10 @@ function score_of_task($details) {
 	    // (with multiplier)
 	    $score *= $gradeobj['.adjustment']['mult'];
 	}
+        if (array_key_exists('.sub', $gradeobj)) {
+            // (with subtraction)
+            $score -= $gradeobj['.sub']['portion'];
+        }
 	return $score;
     }
 

--- a/tools.php
+++ b/tools.php
@@ -772,6 +772,20 @@ function asgn_details($student, $slug) {
         $t = filemtime($path);
         if ($t > $sentin) $sentin = $t;
     }
+    if (file_exists("uploads/$slug/$student/.latest")) {
+        $latest_lines = explode("\n",trim(file_get_contents("uploads/$slug/$student/.latest")));
+        $details['.latest'] = $latest_lines[0];
+        $details['.latest-subdir'] = $latest_lines[1];
+        foreach (glob("uploads/$slug/$student/." . $details['.latest-subdir'] . "/*") as $path) {
+            if (array_key_exists('feedback-files', $details)) {
+                foreach($details['feedback-files'] as $pattern) {
+                    if (fnmatch($pattern, basename($path), FNM_PERIOD)) $feedback = 1;
+                }
+            }
+            if ($feedback) continue;
+            $sentin = filemtime($path);
+        }
+    }
     $details['submitted'] = $sentin;
     $late_days = ($sentin - assignmentTime('due', $details)) / (60 * 60 * 24);
     $details['submitted-late-days'] = $late_days;
@@ -832,11 +846,6 @@ function asgn_details($student, $slug) {
     if (count($feedback_files) > 0)
         $details['.feedback-files'] = $feedback_files;
 
-    if (file_exists("uploads/$slug/$student/.latest")) {
-        $latest_lines = explode("\n",trim(file_get_contents("uploads/$slug/$student/.latest")));
-        $details['.latest'] = $latest_lines[0];
-        $details['.latest-subdir'] = $latest_lines[1];
-    }
     
     // add lists of partners
     $partners = array();

--- a/tools.php
+++ b/tools.php
@@ -780,11 +780,18 @@ function asgn_details($student, $slug) {
             }
             $details['policy-late-penalty'] = $late_policy[$late_days];
             if (array_key_exists('grade', $details)) {
-                $details['grade']['.mult'] = array(
-                    'kind' => 'percentage',
-                    'ratio' => $details['policy-late-penalty'],
-                    'comments' => "$late_days_p1 days late",
-                );
+                if (array_key_exists('.adjustment', $details['grade'])) {
+                    $details['grade']['.adjustment'] = array(
+                        'kind' => 'percentage',
+                        'ratio' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['ratio'],
+                        'comments' => $details['grade']['.adjustment']['comments'] . " and $late_days_p1 days late",
+                    );
+                } else {
+                    $details['grade']['.adjustment'] = array(
+                        'kind' => 'percentage',
+                        'ratio' => $details['policy-late-penalty'],
+                        'comments' => "$late_days_p1 days late",
+                    );
             }
         }
     }

--- a/tools.php
+++ b/tools.php
@@ -18,6 +18,7 @@ if (!array_key_exists('Grading group', $metadata)) $metadata['Grading group'] = 
 /// The following array grants certain users access to the class even if you upload an empty roster or otherwise mess up the course setup. Feel free to add yourself to the set, but remove those it has now at your own risk.
 $superusers = array(
     'lat7h'=>array('name'=>'Luther Tychonievich', 'role'=>'Admin'),
+    'cr4bd'=>array('name'=>'Charles Reiss', 'role'=>'Admin'),
     'no TA'=>array('name'=>'no TA assigned', 'role'=>'Teaching Assistant'),
     'mst3k'=>array('name'=>'Mystery Theater', 'role'=>'Student', 'grader'=>'no TA'),
 );

--- a/tools.php
+++ b/tools.php
@@ -701,6 +701,7 @@ function svg_progress_bar($ep, $fp, $mp) {
  * - rubric (result of rubricOf)
  */
 function asgn_details($student, $slug) {
+    global $isstaff;
     $nopoints = array(
         'correctness' => 0,
         'feedback' => 'Did not submit',
@@ -720,7 +721,7 @@ function asgn_details($student, $slug) {
         $details['excused'] = TRUE;
         $details['weight'] = 0;
     }
-    if (file_exists("uploads/$slug/$student/.grade"))
+    if ((!array_key_exists('withhold',$details) || $isstaff) && file_exists("uploads/$slug/$student/.grade"))
         $details['grade'] = json_decode(file_get_contents("uploads/$slug/$student/.grade"), TRUE);
     if (file_exists("uploads/$slug/$student/.gradetemplate"))
 	$details['grade_template'] = json_decode(file_get_contents("uploads/$slug/$student/.gradetemplate"), TRUE);

--- a/tools.php
+++ b/tools.php
@@ -926,7 +926,7 @@ function cumulative_status($student, &$progress=False, &$projected_score=False) 
         }
         
         // handle future tasks
-        if ($future || !array_key_exists('grade', $details)) {
+        if (!array_key_exists('grade', $details)) {
             $gcode[] = 'future';
             $ans[$details['group']]['future'] += $details['weight'];
             $details['.gcode'] = $gcode;

--- a/tools.php
+++ b/tools.php
@@ -759,11 +759,13 @@ function asgn_details($student, $slug) {
     // add submission time
     $sentin = 0;
     foreach(glob("uploads/$slug/$student/*") as $path) {
+        $feedback = 0;
         if (array_key_exists('feedback-files', $details)) {
             foreach($details['feedback-files'] as $pattern) {
-                if (fnmatch($pattern, basename($path), FNM_PERIOD)) continue;
+                if (fnmatch($pattern, basename($path), FNM_PERIOD)) $feedback = 1;
             }
         }
+        if ($feedback) continue;
         $t = filemtime($path);
         if ($t > $sentin) $sentin = $t;
     }

--- a/tools.php
+++ b/tools.php
@@ -820,7 +820,9 @@ function asgn_details($student, $slug) {
         $details['.feedback-files'] = $feedback_files;
 
     if (file_exists("uploads/$slug/$student/.latest")) {
-        $details['.latest'] = file_get_contents("uploads/$slug/$student/.latest");
+        $latest_lines = explode("\n",trim(file_get_contents("uploads/$slug/$student/.latest")));
+        $details['.latest'] = $latest_lines[0];
+        $details['.latest-subdir'] = $latest_lines[1];
     }
     
     // add lists of partners

--- a/tools.php
+++ b/tools.php
@@ -606,6 +606,15 @@ function rubricOf($slug) {
     return $rubric;
 }
 
+function getShowPointsOption() {
+    global $metadata;
+    if (array_key_exists('show_points', $metadata)) {
+        return $metadata['show_points'];
+    } else {
+        return false;
+    }
+}
+
 
 
 /** returns HTML tags to place a file nicely on the the screen */

--- a/tools.php
+++ b/tools.php
@@ -733,10 +733,6 @@ function asgn_details($student, $slug) {
             'feedback'=> $afb['stdout'],
             'created' => filemtime("uploads/$slug/$student/.autofeedback"),
         );
-    } else if (count(glob("uploads/$slug/$student/*")) > 0) {
-        $details['autograde'] = array(
-            'feedback'=> "no automated tests",
-        );
     } else if (closeTime($details) < time()) {
         $details['autograde'] = $nopoints;
     }

--- a/tools.php
+++ b/tools.php
@@ -792,6 +792,7 @@ function asgn_details($student, $slug) {
                         'ratio' => $details['policy-late-penalty'],
                         'comments' => "$late_days_p1 days late",
                     );
+                }
             }
         }
     }
@@ -1096,6 +1097,10 @@ function score_of_task($details) {
     // combined
     $aw = array_key_exists('auto-weight', $gradeobj) ? $gradeobj['auto-weight'] : 0.5;
     $score = ($human_denom > 0 ? $human/$human_denom*(1-$aw) : 0) + $score*$aw;
+    if (array_key_exists('.sub', $gradeobj)) {
+        // (with subtraction)
+        $score -= $gradeobj['.sub']['portion'];
+    }
     if (array_key_exists('.mult', $gradeobj)) {
         // (with multiplier)
         $score *= $gradeobj['.mult']['ratio'];

--- a/tools.php
+++ b/tools.php
@@ -786,6 +786,7 @@ function asgn_details($student, $slug) {
                     $details['grade']['.adjustment'] = array(
                         'kind' => 'percentage',
                         'ratio' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['ratio'],
+                        'mult' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['ratio'], # FIXME: duplicated
                         'comments' => $details['grade']['.adjustment']['comments'] . " and $late_days_p1 days late",
                     );
                 } else {

--- a/tools.php
+++ b/tools.php
@@ -785,14 +785,12 @@ function asgn_details($student, $slug) {
                 if (array_key_exists('.adjustment', $details['grade'])) {
                     $details['grade']['.adjustment'] = array(
                         'kind' => 'percentage',
-                        'ratio' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['ratio'],
-                        'mult' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['ratio'], # FIXME: duplicated
+                        'mult' => $details['policy-late-penalty'] * $details['grade']['.adjustment']['mult'], # FIXME: duplicated
                         'comments' => $details['grade']['.adjustment']['comments'] . " and $late_days_p1 days late",
                     );
                 } else {
                     $details['grade']['.adjustment'] = array(
                         'kind' => 'percentage',
-                        'ratio' => $details['policy-late-penalty'],
                         'mult' => $details['policy-late-penalty'], # FIXME: duplicated?
                         'comments' => "$late_days_p1 days late",
                     );

--- a/tools.php
+++ b/tools.php
@@ -204,14 +204,15 @@ function updateRosterSpreadsheet($uploadrecord, $remove=False, $keepWaiters=True
     $reader = new SpreadsheetReader($uploadrecord['tmp_name'], $uploadrecord['name'], $uploadrecord['type']);
     foreach($reader->Sheets() as $idx => $name) {
         $reader->ChangeSheet($idx);
-        
         // for some strange reason, Collab exports a roster with several sub-sheets inside each sheet.
         // each has a single title row with just one element, a blank row, and then the header and contents
         // since spreadsheet-reader skips empty lines in xlsx, we look for <= 1
         $blank = true;
-        $header = array();
+	$header = array();
 
-        foreach ($reader as $row) {
+	$reader->rewind();
+
+	foreach ($reader as $row) {
             if (count($row) <= 1) { $blank = true; }
             else if ($blank) {
                 $header = array();


### PR DESCRIPTION
These add a cleaned-up version the changes to the archimedes I used in CS 4414. I believe I've edited changes to be configurable, so there doesn't need to be a separate version of the scripts for different courses (to the extent anyone's using the "stock" version) despite differences in how the archimedes tools are used. (Hopefully I didn't miss anything; I made some changes during the semester which I later fixed to try to make them more generic.) Changes are mostly documented in the README.md and include:

* support for a `single-file` flag on assignments in assignments.json to interpret the submission as only the most recent version of a file matching the pattern. (In CS 4414, I provided a `make submit` target that produces a file like `assignmentname-TIMESTAMP.tar.gz`.) Along with this, the current submission is tracked in a `.latest` file in each students uploads directory, along with an option to revert the current submission to an older version.

* support for a `feedback-files` list for assignments in assignments.json. This has the same format as the `files` list and is intended for files that will be generated by an autograder and should be made available for students to see. These files will be shown in a separate category on the submission page and their timestamps won't be taken into account

* support for a `kind` field on "human" rubric items in the hybrid grade type, which can be one of
   * radio3 (default): three radio buttons
   * radio5: five radio buttons (0/.25/5/.75/1)
   * points: enter an amount of points (based on weight)
   * comment: item has no weight, but allow for a standalone comment

* support for marking items with the "human" rubric item within the hybrid grade type as accepting a "N/A" option, which will set their weight to none

* support for a "key" flag on "human" rubric items to allow matching up rubric items after tweaking their displayed description;

* support for per-item comments in the grading interface (not enabled by default)

* support for a `withhold` flag on assignments. If set, the assignment's grades won't be shown to students, but it will be open for grading.

* a "respond without regrading" option in the regrade page, which just adds to the .chat

* grade.php looks for a .gradetemplate file to initialize the displayed grades, to allow an autograder to include guesses for human graders;

* support for a special-case substraction (instead of multiply), not enabled by default

* ability to customize the "task description" link text on tasks, the "not submitted online" text on the index of tasks

* extension requests extend close time, too

* optional support to show score before late penalty and special-case adjustments on task feedback screen

* support (copied from CS 111x's exam grading stuff) for hidden assignments that are gradeable but not shown to students or factored into grade computations